### PR TITLE
[CDEVOPS-687] Pull Service Provider Setting from Upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :test do
 end
 
 group :development do
+  gem "fog-openstack", "0.1.25" if RUBY_VERSION < '2.2.0'
   gem "beaker-rspec"
   gem "beaker", '3.31.0'
   gem "guard-rake"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -266,6 +266,7 @@ class datadog_agent(
   $agent5_repo_uri = $datadog_agent::params::agent5_default_repo,
   $agent6_repo_uri = $datadog_agent::params::agent6_default_repo,
   $apt_release = $datadog_agent::params::apt_default_release,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   # Allow ports to be passed as integers or strings.
@@ -375,6 +376,7 @@ class datadog_agent(
         class { 'datadog_agent::ubuntu::agent5':
           service_ensure        => $service_ensure,
           service_enable        => $service_enable,
+          service_provider      => $service_provider,
           location              => $agent5_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
@@ -383,6 +385,7 @@ class datadog_agent(
         class { 'datadog_agent::ubuntu::agent6':
           service_ensure        => $service_ensure,
           service_enable        => $service_enable,
+          service_provider      => $service_provider,
           location              => $agent6_repo_uri,
           release               => $apt_release,
           skip_apt_key_trusting => $skip_apt_key_trusting,
@@ -392,17 +395,19 @@ class datadog_agent(
     'RedHat','CentOS','Fedora','Amazon','Scientific' : {
       if $agent5_enable {
         class { 'datadog_agent::redhat::agent5':
-          baseurl        => $agent5_repo_uri,
-          manage_repo    => $manage_repo,
-          service_ensure => $service_ensure,
-          service_enable => $service_enable,
+          baseurl          => $agent5_repo_uri,
+          manage_repo      => $manage_repo,
+          service_ensure   => $service_ensure,
+          service_enable   => $service_enable,
+          service_provider => $service_provider,
         }
       } else {
         class { 'datadog_agent::redhat::agent6':
-          baseurl        => $agent6_repo_uri,
-          manage_repo    => $manage_repo,
-          service_ensure => $service_ensure,
-          service_enable => $service_enable,
+          baseurl          => $agent6_repo_uri,
+          manage_repo      => $manage_repo,
+          service_ensure   => $service_ensure,
+          service_enable   => $service_enable,
+          service_provider => $service_provider,
         }
       }
     }

--- a/manifests/redhat/agent5.pp
+++ b/manifests/redhat/agent5.pp
@@ -21,6 +21,7 @@ class datadog_agent::redhat::agent5(
   String $agent_version = 'latest',
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   validate_legacy('Boolean', 'validate_bool', $manage_repo)
@@ -89,12 +90,23 @@ class datadog_agent::redhat::agent5(
     ensure  => $agent_version,
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package[$datadog_agent::params::package_name],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
   }
 
 }

--- a/manifests/redhat/agent6.pp
+++ b/manifests/redhat/agent6.pp
@@ -10,6 +10,7 @@ class datadog_agent::redhat::agent6(
   String $agent_version = 'latest',
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   validate_legacy('Boolean', 'validate_bool', $manage_repo)
@@ -63,13 +64,23 @@ class datadog_agent::redhat::agent6(
     ensure  => $agent_version,
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    provider  => 'upstart', # Needed for Amazon Linux
-    require   => Package[$datadog_agent::params::package_name],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
   }
 
 }

--- a/manifests/ubuntu/agent5.pp
+++ b/manifests/ubuntu/agent5.pp
@@ -22,6 +22,7 @@ class datadog_agent::ubuntu::agent5(
   Boolean $skip_apt_key_trusting = false,
   String $service_ensure = 'running',
   Boolean $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params{
 
   ensure_packages(['apt-transport-https'])
@@ -83,11 +84,22 @@ class datadog_agent::ubuntu::agent5(
                 Exec['apt_update']],
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package[$datadog_agent::params::package_name],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package[$datadog_agent::params::package_name],
+    }
   }
 }

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -13,6 +13,7 @@ class datadog_agent::ubuntu::agent6(
   $skip_apt_key_trusting = false,
   $service_ensure = 'running',
   $service_enable = true,
+  Optional[String] $service_provider = undef,
 ) inherits datadog_agent::params {
 
   ensure_packages(['apt-transport-https'])
@@ -50,11 +51,22 @@ class datadog_agent::ubuntu::agent6(
                 Exec['apt_update']],
   }
 
-  service { $datadog_agent::params::service_name:
-    ensure    => $service_ensure,
-    enable    => $service_enable,
-    hasstatus => false,
-    pattern   => 'dd-agent',
-    require   => Package['datadog-agent'],
+  if $service_provider {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package['datadog-agent'],
+    }
+  } else {
+    service { $datadog_agent::params::service_name:
+      ensure    => $service_ensure,
+      enable    => $service_enable,
+      hasstatus => false,
+      pattern   => 'dd-agent',
+      require   => Package['datadog-agent'],
+    }
   }
 }

--- a/spec/classes/datadog_agent_redhat_spec.rb
+++ b/spec/classes/datadog_agent_redhat_spec.rb
@@ -28,6 +28,21 @@ describe 'datadog_agent::redhat::agent5' do
       should_not contain_yumrepo('datadog6')
     end
   end
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
+    end
+  end
 
 
   # it should install the packages
@@ -74,6 +89,21 @@ describe 'datadog_agent::redhat::agent6' do
       should_not contain_yumrepo('datadog')
       should_not contain_yumrepo('datadog5')
       should_not contain_yumrepo('datadog6')
+    end
+  end
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
     end
   end
 

--- a/spec/classes/datadog_agent_spec.rb
+++ b/spec/classes/datadog_agent_spec.rb
@@ -774,6 +774,24 @@ describe 'datadog_agent' do
             end
 
             end
+
+            context 'with service provider override' do
+              let(:params) {{
+                  :service_provider => 'upstart',
+              }}
+              it do
+                should contain_service('datadog-agent')\
+                  .that_requires('package[datadog-agent]')
+              end
+              it do
+                should contain_service('datadog-agent').with(
+                  'provider' => 'upstart',
+                  'ensure' => 'running',
+                )
+              end
+            end
+
+          end
         end
 
         if DEBIAN_OS.include?(operatingsystem)
@@ -846,7 +864,19 @@ describe 'datadog_agent' do
               'content' => /^process_config:\n/,
               )}
               it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
-              'content' => /^\ \ process_enabled: disabled\n/,
+              'content' => /^\ \ enabled: disabled\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ scrub_args: true\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ custom_sensitive_words: \[\]\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^logs_enabled: false\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^logs_config:\n\ \ container_collect_all: false\n/,
               )}
             end
           end
@@ -930,6 +960,79 @@ describe 'datadog_agent' do
               'content' => /^\ \ bar: haz\n/,
               )}
             end
+          end
+
+          context 'with data scrubbing custom options' do
+            context 'with data scrubbing disabled' do
+              let(:params) {{
+                  :process_enabled => true,
+                  :scrub_args => false
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^process_config:\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ enabled: 'true'\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ scrub_args: false\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ custom_sensitive_words: \[\]\n/,
+              )}
+            end
+
+            context 'with data scrubbing enabled with custom sensitive_words' do
+              let(:params) {{
+                  :process_enabled => true,
+                  :custom_sensitive_words => ['consul_token','dd_key']
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^process_config:\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ enabled: 'true'\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ scrub_args: true\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ -\ consul_token\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^\ \ -\ dd_key\n/,
+              )}
+            end
+
+            context 'with logs enabled' do
+              let(:params) {{
+                  :logs_enabled => true,
+                  :container_collect_all => true
+              }}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^logs_enabled: true\n/,
+              )}
+              it { should contain_file('/etc/datadog-agent/datadog.yaml').with(
+              'content' => /^logs_config:\n\ \ container_collect_all: true\n/,
+              )}
+            end
+
+            context 'with service provider override' do
+              let(:params) {{
+                  :service_provider => 'upstart',
+              }}
+              it do
+                should contain_service('datadog-agent')\
+                  .that_requires('package[datadog-agent]')
+              end
+              it do
+                should contain_service('datadog-agent').with(
+                  'provider' => 'upstart',
+                  'ensure' => 'running',
+                )
+              end
+            end
+
           end
         end
       end

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -45,6 +45,22 @@ describe 'datadog_agent::ubuntu::agent5' do
     should contain_service('datadog-agent')\
       .that_requires('package[datadog-agent]')
   end
+
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
+    end
+  end
 end
 
 describe 'datadog_agent::ubuntu::agent6' do
@@ -92,5 +108,21 @@ describe 'datadog_agent::ubuntu::agent6' do
   it do
     should contain_service('datadog-agent')\
       .that_requires('package[datadog-agent]')
+  end
+
+  context 'overriding provider' do
+    let(:params) {{
+      service_provider: 'upstart',
+    }}
+    it do
+      should contain_service('datadog-agent')\
+        .that_requires('package[datadog-agent]')
+    end
+    it do
+      should contain_service('datadog-agent').with(
+        'provider' => 'upstart',
+        'ensure' => 'running',
+      )
+    end
   end
 end


### PR DESCRIPTION
This change from https://github.com/DataDog/puppet-datadog-agent/pull/444 should allow us to set systemd or upstart as the service provider on AWS Linux, in preparation for the upgrade to AWS Linux 2. This can be done with `datadog_agent::service_provider` in the Hieradata for ECS.